### PR TITLE
Choose if typeahead input containing value without matches should be cleared on lost focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,12 @@ The following options are available on the elemicaSuggest function:
   event a selection has been made, we pass in the suggestion object representing that suggestion. In
   the event that a selection has been cleared, we pass in `null`. This callback is invoked on each
   selection the user makes, including identical selections.
-- noSuggestionMatched: (optional) A function to be invoked after user left typeahead input and no suggestion
-  matched entered value. If function returns truthy, input will be cleared. That's the default
-  behaviour. If function returns falsey, input will remain filled. Callback accepts single 
-  parameter - it's the unmatched input field value.
+- noSuggestionMatched: (optional) A function to be invoked after user left typeahead input and no
+  suggestion matched entered value. If function returns truthy, input will be cleared. That's the
+  default behaviour. If function returns falsey, input will remain filled. Also, falsey value returned
+  from callback leds to breaking callbacks chain and afterSelect callback is not going to be invoked. 
+  noSuggestionMatched accepts two parameters - the unmatched input field value and reference 
+  to afterSelect in case developer wants to invoke it manually.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ The following options are available on the elemicaSuggest function:
   selection the user makes, including identical selections.
 - noSuggestionMatched: (optional) A function to be invoked after user left typeahead input and no suggestion
   matched entered value. If function returns `true`, input will be cleared. That's the default
-  behaviour. If function return `false`, input will remain filled.
+  behaviour. If function return `false`, input will remain filled. Callback accepts single 
+  parameter - it's the unmatched input field value.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ The following options are available on the elemicaSuggest function:
   - metadata: (optional) Some additional metadata text associated with the suggestion.
 - valueInput: A jQuery object representing the DOM node which will receive
   the value selected by the user.
-- clearIncompleteSearchInput: (optional) Indicates whether typeahead input should be cleared
-  on focus lost if one of the suggested values was not selected. Defaults to 'true'.
 - minimumSearchTermLength: (optional) The minimum number of characters the end-user needs
   to type in the text box before elemica-suggest starts making suggestions.
 - selectionIndicatorTarget: (optional) A function that takes in a jQuery object that represents
@@ -130,6 +128,9 @@ The following options are available on the elemicaSuggest function:
   event a selection has been made, we pass in the suggestion object representing that suggestion. In
   the event that a selection has been cleared, we pass in `null`. This callback is invoked on each
   selection the user makes, including identical selections.
+- noSuggestionMatched: (optional) A function to be invoked after user left typeahead input and no suggestion
+  matched entered value. If function returns `true`, input will be cleared. That's the default
+  behaviour. If function return `false`, input will remain filled.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The following options are available on the elemicaSuggest function:
   - metadata: (optional) Some additional metadata text associated with the suggestion.
 - valueInput: A jQuery object representing the DOM node which will receive
   the value selected by the user.
+- clearIncompleteSearchInput: (optional) Indicates whether typeahead input should be cleared
+  on focus lost if one of the suggested values was not selected. Defaults to 'true'.
 - minimumSearchTermLength: (optional) The minimum number of characters the end-user needs
   to type in the text box before elemica-suggest starts making suggestions.
 - selectionIndicatorTarget: (optional) A function that takes in a jQuery object that represents

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ The following options are available on the elemicaSuggest function:
   the event that a selection has been cleared, we pass in `null`. This callback is invoked on each
   selection the user makes, including identical selections.
 - noSuggestionMatched: (optional) A function to be invoked after user left typeahead input and no suggestion
-  matched entered value. If function returns `true`, input will be cleared. That's the default
-  behaviour. If function return `false`, input will remain filled. Callback accepts single 
+  matched entered value. If function returns truthy, input will be cleared. That's the default
+  behaviour. If function returns falsey, input will remain filled. Callback accepts single 
   parameter - it's the unmatched input field value.
 
 ## Developing

--- a/dist/elemica-suggest.js
+++ b/dist/elemica-suggest.js
@@ -11,7 +11,7 @@ elemicaSuggest 0.7.1-SNAPSHOT.
     noop = function() {};
     return $.fn.extend({
       elemicaSuggest: function(options) {
-        var $valueInput, BACKSPACE, DOWN_ARROW, ENTER, TAB, UP_ARROW, afterSelect, afterSuggest, clearIncompleteSearchInput, highlightAnother, highlightNext, highlightPrevious, isSelectingSuggestion, minimumSearchTermLength, noMatchesMessage, populateSuggestions, removeSuggestions, selectHighlighted, selectionIndicatorTarget, suggestFunction;
+        var $valueInput, BACKSPACE, DOWN_ARROW, ENTER, TAB, UP_ARROW, afterSelect, afterSuggest, highlightAnother, highlightNext, highlightPrevious, isSelectingSuggestion, minimumSearchTermLength, noMatchesMessage, noSuggestionMatched, populateSuggestions, removeSuggestions, selectHighlighted, selectionIndicatorTarget, suggestFunction;
         if (options == null) {
           options = {};
         }
@@ -27,7 +27,6 @@ elemicaSuggest 0.7.1-SNAPSHOT.
           return typeof console !== "undefined" && console !== null ? console.warn("No suggest function defined.") : void 0;
         };
         minimumSearchTermLength = options.minimumSearchTermLength || 2;
-        clearIncompleteSearchInput = options.clearIncompleteSearchInput != null ? options.clearIncompleteSearchInput : true;
         $valueInput = options.valueInput || $("<input />");
         selectionIndicatorTarget = options.selectionIndicatorTarget || function($target) {
           return $target;
@@ -35,6 +34,9 @@ elemicaSuggest 0.7.1-SNAPSHOT.
         noMatchesMessage = options.noMatchesMessage || $(this.first()).data('no-matches');
         afterSuggest = options.afterSuggest || noop;
         afterSelect = options.afterSelect || noop;
+        noSuggestionMatched = options.noSuggestionMatched || function() {
+          return true;
+        };
         removeSuggestions = function(element) {
           return $(element).siblings(".suggestions").remove();
         };
@@ -107,7 +109,7 @@ elemicaSuggest 0.7.1-SNAPSHOT.
           $(this).on('blur', function(event) {
             removeSuggestions(event.target);
             if ($valueInput.val() === "") {
-              if (clearIncompleteSearchInput) {
+              if (noSuggestionMatched()) {
                 $(event.target).val("");
               }
               return afterSelect(null);

--- a/dist/elemica-suggest.js
+++ b/dist/elemica-suggest.js
@@ -111,10 +111,10 @@ elemicaSuggest 0.7.1-SNAPSHOT.
             $target = $(event.target);
             removeSuggestions($target);
             if ($valueInput.val() === "") {
-              if (noSuggestionMatched($target.val())) {
+              if (noSuggestionMatched($target.val(), afterSelect)) {
                 $target.val("");
+                return afterSelect(null);
               }
-              return afterSelect(null);
             }
           });
           $(this).on('keydown', (function(_this) {

--- a/dist/elemica-suggest.js
+++ b/dist/elemica-suggest.js
@@ -11,7 +11,7 @@ elemicaSuggest 0.7.1-SNAPSHOT.
     noop = function() {};
     return $.fn.extend({
       elemicaSuggest: function(options) {
-        var $valueInput, BACKSPACE, DOWN_ARROW, ENTER, TAB, UP_ARROW, afterSelect, afterSuggest, highlightAnother, highlightNext, highlightPrevious, isSelectingSuggestion, minimumSearchTermLength, noMatchesMessage, populateSuggestions, removeSuggestions, selectHighlighted, selectionIndicatorTarget, suggestFunction;
+        var $valueInput, BACKSPACE, DOWN_ARROW, ENTER, TAB, UP_ARROW, afterSelect, afterSuggest, clearIncompleteSearchInput, highlightAnother, highlightNext, highlightPrevious, isSelectingSuggestion, minimumSearchTermLength, noMatchesMessage, populateSuggestions, removeSuggestions, selectHighlighted, selectionIndicatorTarget, suggestFunction;
         if (options == null) {
           options = {};
         }
@@ -27,6 +27,7 @@ elemicaSuggest 0.7.1-SNAPSHOT.
           return typeof console !== "undefined" && console !== null ? console.warn("No suggest function defined.") : void 0;
         };
         minimumSearchTermLength = options.minimumSearchTermLength || 2;
+        clearIncompleteSearchInput = options.clearIncompleteSearchInput != null ? options.clearIncompleteSearchInput : true;
         $valueInput = options.valueInput || $("<input />");
         selectionIndicatorTarget = options.selectionIndicatorTarget || function($target) {
           return $target;
@@ -106,7 +107,9 @@ elemicaSuggest 0.7.1-SNAPSHOT.
           $(this).on('blur', function(event) {
             removeSuggestions(event.target);
             if ($valueInput.val() === "") {
-              $(event.target).val("");
+              if (clearIncompleteSearchInput) {
+                $(event.target).val("");
+              }
               return afterSelect(null);
             }
           });

--- a/dist/elemica-suggest.js
+++ b/dist/elemica-suggest.js
@@ -107,10 +107,12 @@ elemicaSuggest 0.7.1-SNAPSHOT.
         return this.each(function() {
           $(this).attr('autocomplete', 'off');
           $(this).on('blur', function(event) {
-            removeSuggestions(event.target);
+            var $target;
+            $target = $(event.target);
+            removeSuggestions($target);
             if ($valueInput.val() === "") {
-              if (noSuggestionMatched()) {
-                $(event.target).val("");
+              if (noSuggestionMatched($target.val())) {
+                $target.val("");
               }
               return afterSelect(null);
             }

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -35,8 +35,8 @@ elemicaSuggest 0.7.1-SNAPSHOT.
 # - afterSelect: A function to be invoked after a selection has been made. Will pass in the entire
 #   suggestion object that was selected by the user.
 # - noSuggestionMatched: (optional) A function to be invoked after user left typeahead input and no
-#   suggestion matched entered value. If function returns true, input will be cleared. That's the
-#   default behaviour. If function return false, input will remain filled. Callback accepts single
+#   suggestion matched entered value. If function returns truthy, input will be cleared. That's the
+#   default behaviour. If function returns falsey, input will remain filled. Callback accepts single
 #   parameter - it's the unmatched input field value.
 ##
 (($) ->

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -36,7 +36,8 @@ elemicaSuggest 0.7.1-SNAPSHOT.
 #   suggestion object that was selected by the user.
 # - noSuggestionMatched: (optional) A function to be invoked after user left typeahead input and no
 #   suggestion matched entered value. If function returns true, input will be cleared. That's the
-#   default behaviour. If function return false, input will remain filled.
+#   default behaviour. If function return false, input will remain filled. Callback accepts single
+#   parameter - it's the unmatched input field value.
 ##
 (($) ->
   noop = ->
@@ -159,10 +160,11 @@ elemicaSuggest 0.7.1-SNAPSHOT.
         $(this).attr 'autocomplete', 'off'
 
         $(this).on 'blur', (event) ->
-          removeSuggestions event.target
+          $target = $(event.target)
+          removeSuggestions $target
 
           if $valueInput.val() == ""
-            $(event.target).val("") if noSuggestionMatched()
+            $target.val("") if noSuggestionMatched($target.val())
             afterSelect(null)
 
         $(this).on 'keydown', (event) =>

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -24,8 +24,6 @@ elemicaSuggest 0.7.1-SNAPSHOT.
 #   to initate a typeahead search. Defaults to 2.
 # - valueInput: A jQuery object representing the DOM node which will receive
 #   the value selected by the user.
-# - clearIncompleteSearchInput: (optional) Indicates whether typeahead input should be cleared
-#   on focus lost if one of the suggested values was not selected. Defaults to 'true'.
 # - selectionIndicatorTarget: A function that takes in a jQuery object that represents
 #   the input and operates on that object to return a jQuery object of the element(s)
 #   that will receive the has-selection CSS class when a selection is made. By default
@@ -36,6 +34,9 @@ elemicaSuggest 0.7.1-SNAPSHOT.
 # - afterSuggest: A function to be invoked after suggestions have been populated.
 # - afterSelect: A function to be invoked after a selection has been made. Will pass in the entire
 #   suggestion object that was selected by the user.
+# - noSuggestionMatched: (optional) A function to be invoked after user left typeahead input and no
+#   suggestion matched entered value. If function returns true, input will be cleared. That's the
+#   default behaviour. If function return false, input will remain filled.
 ##
 (($) ->
   noop = ->
@@ -56,11 +57,6 @@ elemicaSuggest 0.7.1-SNAPSHOT.
         console?.warn "No suggest function defined."
 
       minimumSearchTermLength = options.minimumSearchTermLength || 2
-      
-      clearIncompleteSearchInput = if options.clearIncompleteSearchInput?
-        options.clearIncompleteSearchInput
-      else
-        true
 
       $valueInput = options.valueInput || $("<input />")
 
@@ -71,6 +67,8 @@ elemicaSuggest 0.7.1-SNAPSHOT.
       afterSuggest = options.afterSuggest || noop
 
       afterSelect = options.afterSelect || noop
+      
+      noSuggestionMatched = options.noSuggestionMatched || -> true
 
       removeSuggestions = (element) ->
         $(element).siblings(".suggestions").remove()
@@ -164,7 +162,7 @@ elemicaSuggest 0.7.1-SNAPSHOT.
           removeSuggestions event.target
 
           if $valueInput.val() == ""
-            $(event.target).val("") if clearIncompleteSearchInput
+            $(event.target).val("") if noSuggestionMatched()
             afterSelect(null)
 
         $(this).on 'keydown', (event) =>

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -36,8 +36,10 @@ elemicaSuggest 0.7.1-SNAPSHOT.
 #   suggestion object that was selected by the user.
 # - noSuggestionMatched: (optional) A function to be invoked after user left typeahead input and no
 #   suggestion matched entered value. If function returns truthy, input will be cleared. That's the
-#   default behaviour. If function returns falsey, input will remain filled. Callback accepts single
-#   parameter - it's the unmatched input field value.
+#   default behaviour. If function returns falsey, input will remain filled. Also, falsey value returned
+#   from callback leds to breaking callbacks chain and afterSelect callback is not going to be invoked. 
+#   noSuggestionMatched accepts two parameters - the unmatched input field value and reference 
+#   to afterSelect in case developer wants to invoke it manually.
 ##
 (($) ->
   noop = ->
@@ -164,8 +166,9 @@ elemicaSuggest 0.7.1-SNAPSHOT.
           removeSuggestions $target
 
           if $valueInput.val() == ""
-            $target.val("") if noSuggestionMatched($target.val())
-            afterSelect(null)
+            if noSuggestionMatched($target.val(), afterSelect)
+              $target.val("")
+              afterSelect(null)
 
         $(this).on 'keydown', (event) =>
           if event.keyCode == UP_ARROW || event.keyCode == DOWN_ARROW

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -24,6 +24,8 @@ elemicaSuggest 0.7.1-SNAPSHOT.
 #   to initate a typeahead search. Defaults to 2.
 # - valueInput: A jQuery object representing the DOM node which will receive
 #   the value selected by the user.
+# - clearIncompleteSearchInput: (optional) Indicates whether typeahead input should be cleared
+#   on focus lost if one of the suggested values was not selected. Defaults to 'true'.
 # - selectionIndicatorTarget: A function that takes in a jQuery object that represents
 #   the input and operates on that object to return a jQuery object of the element(s)
 #   that will receive the has-selection CSS class when a selection is made. By default
@@ -54,6 +56,11 @@ elemicaSuggest 0.7.1-SNAPSHOT.
         console?.warn "No suggest function defined."
 
       minimumSearchTermLength = options.minimumSearchTermLength || 2
+      
+      clearIncompleteSearchInput = if options.clearIncompleteSearchInput?
+        options.clearIncompleteSearchInput
+      else
+        true
 
       $valueInput = options.valueInput || $("<input />")
 
@@ -157,7 +164,7 @@ elemicaSuggest 0.7.1-SNAPSHOT.
           removeSuggestions event.target
 
           if $valueInput.val() == ""
-            $(event.target).val("")
+            $(event.target).val("") if clearIncompleteSearchInput
             afterSelect(null)
 
         $(this).on 'keydown', (event) =>

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -169,7 +169,7 @@ describe 'Suggest', ->
     $input.trigger('blur')
     $input.val().should.equal('')
     
-  it 'should not clear typehead input when no valid selection was made and noSuggestionMatched returns false', ->
+  it 'should not clear typehead input when no valid selection was made and noSuggestionMatched returned falsey', ->
     suggestFunction = (searchTerm, populateFn) ->
       populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])      
         
@@ -183,3 +183,16 @@ describe 'Suggest', ->
     
     $input.trigger('blur')
     $input.val().should.equal('bacon')
+    
+  it 'should not invoke afterSelect when no valid selection was made and noSuggestionMatched returned falsey', ->
+    suggestFunction = (searchTerm, populateFn) ->
+      populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])
+
+    $input = $("<input />")
+    $input.elemicaSuggest
+      suggestFunction: suggestFunction
+      noSuggestionMatched: -> false
+      afterSelect: -> throw new Error('afterSelect should not be run if noSuggestionMatched return falsey')
+
+    $input.val('bacon').trigger('keyup')
+    $input.trigger('blur')

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -127,14 +127,16 @@ describe 'Suggest', ->
 
   it 'should invoke noSuggestionMatched callback if no valid selection was made', (done) ->
     suggestFunction = (searchTerm, populateFn) ->
-      populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])      
+      populateFn([{display: 'bacon', value: 'bacon'}])
           
     $input = $("<input />")
     $input.elemicaSuggest
       suggestFunction: suggestFunction
-      noSuggestionMatched: -> done()
+      noSuggestionMatched: (value) -> 
+        value.should.equal('lol')
+        done()
           
-    $input.val('suggestion 1').trigger('keyup')
+    $input.val('lol').trigger('keyup')
     $input.trigger('blur')
     
   it 'should not invoke noSuggestionMatched callback if valid selection was made', ->

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -125,6 +125,34 @@ describe 'Suggest', ->
     $input.val('bacon').trigger('keyup')
     $containerDiv.find(".suggestions .active").trigger('element-selected')
 
+  it 'should invoke noSuggestionMatched callback if no valid selection was made', (done) ->
+    suggestFunction = (searchTerm, populateFn) ->
+      populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])      
+          
+    $input = $("<input />")
+    $input.elemicaSuggest
+      suggestFunction: suggestFunction
+      noSuggestionMatched: -> done()
+          
+    $input.val('suggestion 1').trigger('keyup')
+    $input.trigger('blur')
+    
+  it 'should not invoke noSuggestionMatched callback if valid selection was made', ->
+    invocationCount = 0
+    suggestFunction = (searchTerm, populateFn) ->
+      populateFn([{display: 'bacon', value: 'bacon'}])
+
+    $input = $("<input />")
+    $input.elemicaSuggest
+      suggestFunction: suggestFunction
+      noSuggestionMatched: -> invocationCount++
+
+    $containerDiv = $("<div />").append($input)
+    $input.val('bacon').trigger('keyup')
+    $containerDiv.find(".suggestions .active").trigger('element-selected')
+
+    invocationCount.should.equal(0)
+
   it 'should clear typeahead input by default when no valid selection was made', ->
     suggestFunction = (searchTerm, populateFn) ->
       populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])
@@ -139,14 +167,14 @@ describe 'Suggest', ->
     $input.trigger('blur')
     $input.val().should.equal('')
     
-  it 'should not clear typehead input with clearIncompleteSearchInput=false when no valid selection was made', ->
+  it 'should not clear typehead input when no valid selection was made and noSuggestionMatched returns false', ->
     suggestFunction = (searchTerm, populateFn) ->
       populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])      
         
     $input = $("<input />")
     $input.elemicaSuggest
       suggestFunction: suggestFunction
-      clearIncompleteSearchInput: false
+      noSuggestionMatched: -> false
         
     $input.val('bacon').trigger('keyup')
     $input.val().should.equal('bacon')

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -124,3 +124,32 @@ describe 'Suggest', ->
     $containerDiv = $("<div />").append($input)
     $input.val('bacon').trigger('keyup')
     $containerDiv.find(".suggestions .active").trigger('element-selected')
+
+  it 'should clear typeahead input by default when no valid selection was made', ->
+    suggestFunction = (searchTerm, populateFn) ->
+      populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])
+    
+    $input = $("<input />")
+    $input.elemicaSuggest
+      suggestFunction: suggestFunction
+    
+    $input.val('bacon').trigger('keyup')
+    $input.val().should.equal('bacon')
+    
+    $input.trigger('blur')
+    $input.val().should.equal('')
+    
+  it 'should not clear typehead input with clearIncompleteSearchInput=false when no valid selection was made', ->
+    suggestFunction = (searchTerm, populateFn) ->
+      populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])      
+        
+    $input = $("<input />")
+    $input.elemicaSuggest
+      suggestFunction: suggestFunction
+      clearIncompleteSearchInput: false
+        
+    $input.val('bacon').trigger('keyup')
+    $input.val().should.equal('bacon')
+    
+    $input.trigger('blur')
+    $input.val().should.equal('bacon')


### PR DESCRIPTION
In some cases it is not desirable to clear typeahead input on lost focus if one of the suggested values was not selected. For instance, user may have an inline option to create some entity if no matching value was found. In this case, typeahead input should remain filled on lost focus. On the other hand, sometimes, we want to enforce user to select one of the suggested values that come from already existing entities. In this case typeahead input should be cleared if no valid selection was made.