### PR TITLE
Triptych: Add C-N/C-P support for movement and match marking in the suggestion HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,25 @@ to style that `ul` however you like.
 
 ### CSS Classes
 
-The elemica-suggest library is pretty intentionally unstyled when you first drop it in. This
-is an intentional decision. You are the one building your app, and you should be the one to
-dictate what it looks like - typeahead suggestions and all. To facilitate this we use a few
-different CSS classes to help you with your styling.
+The elemica-suggest library is pretty unstyled when you first drop it in. This
+is an intentional decision. You are the one building your app, and you should
+be the one to dictate what it looks like - typeahead suggestions and all. To
+facilitate this we use a few different CSS classes to help you with your
+styling.
 
 * **suggestions** is applied to the `ul` that contains the suggestions that are being made.
 * **active** is applied to the `li` inside `ul.suggestions` that is currently selected by the
-  user. A suggestion can become active by the user using the up or down arrow keys or by hovering
-  over the `li` with their mouse.
+  user. A suggestion can become active by the user using the up or down arrow
+  keys, or by using Ctrl-N or Ctrl-P, or by hovering over the `li` with their
+  mouse.
 * **has-selection** is applied to an element to indicate that a selection has been made. By default
   this element is the text field itself, but if you have need you can provide a value for the
   `selectionIndicatorTarget` parameter (see below) and change where this class is applied.
 * **invalid-text** is applied to a suggestion `li` when that suggestion `li` is a message informing
   the user that there are no matches for their query.
+* **match** is applied to spans inside suggestions when part of the suggestion
+  is matched by a capturing group in the regular expression returned by the
+  `buildMarkerRegExp` function, if provided.
 
 ### Using Dev Tools
 
@@ -116,6 +121,12 @@ The following options are available on the elemicaSuggest function:
   the value selected by the user.
 - minimumSearchTermLength: (optional) The minimum number of characters the end-user needs
   to type in the text box before elemica-suggest starts making suggestions.
+- buildMarkerRegExp: (optional) A function that is given the current search
+  term, and is expected to return a regular expression whose capturing groups
+  will be used to mark the suggestions with the class `match`. For example, if
+  the search term was "hello", you could return /(hello)/ to mark all instances
+  of that word in all suggestions with the `match` class. Each match is wrapped
+  in a `span`.
 - selectionIndicatorTarget: (optional) A function that takes in a jQuery object that represents
   the input and operates on that object to return a jQuery object of the element(s)
   that will receive the has-selection CSS class when a selection is made. By default

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
   "authors": [
     "Matt Farmer <matt@frmr.me>",
     "Łukasz Lenart <lukasz@softwaremill.pl>",
-    "Piotr Dyraga <piotr.dyraga@softwaremill.pl>"
+    "Piotr Dyraga <piotr.dyraga@softwaremill.pl>",
+    "Antonio Salazar Cardozo <savedfastcool@gmail.com>"
   ],
   "description": "A lightweight suggestion typeahead library that makes your life better by doing less.",
   "main": "elemica-suggest.coffee",

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -182,13 +182,13 @@ elemicaSuggest 0.9.2-SNAPSHOT
               afterSelect(null) if originalValue != ""
 
         $(this).on 'keydown', (event) =>
-          if event.keyCode == UP_ARROW || event.keyCode == DOWN_ARROW
+          if event.which == UP_ARROW || event.which == DOWN_ARROW
             event.preventDefault()
-          else if event.keyCode == ENTER && isSelectingSuggestion()
+          else if event.which == ENTER && isSelectingSuggestion()
             event.preventDefault()
-          else if event.keyCode == TAB && isSelectingSuggestion()
+          else if event.which == TAB && isSelectingSuggestion()
             selectHighlighted(this)
-          else if event.keyCode == BACKSPACE && $valueInput.val() != ""
+          else if event.which == BACKSPACE && $valueInput.val() != ""
             $valueInput.val("")
             $(event.target).val("")
             afterSelect(null)

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -28,8 +28,8 @@ elemicaSuggest 0.9.2-SNAPSHOT
 #   expected to return a regular expression whose capturing groups will be used
 #   to mark the suggestions with the class `match`. For example, if the search
 #   term was "hello", you could return /(hello)/ to mark all instances of that
-#   word in all suggestions with the `match` class. The matches are wrapped in
-#   a span.
+#   word in all suggestions with the `match` class. Each match is wrapped in a
+#   `span`.
 # - selectionIndicatorTarget: A function that takes in a jQuery object that represents
 #   the input and operates on that object to return a jQuery object of the element(s)
 #   that will receive the has-selection CSS class when a selection is made. By default

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -46,6 +46,8 @@ elemicaSuggest 0.9.2-SNAPSHOT
 
   $.fn.extend
     elemicaSuggest: (options = {}) ->
+      KEY_N = 78
+      KEY_P = 80
       UP_ARROW = 38
       DOWN_ARROW = 40
       ENTER = 13
@@ -194,12 +196,15 @@ elemicaSuggest 0.9.2-SNAPSHOT
             afterSelect(null)
 
         $(this).on 'keyup', (event) =>
-          switch event.keyCode
-            when UP_ARROW
+          key = event.which
+          ctrlPressed = event.ctrlKey
+
+          switch
+            when key is UP_ARROW || (ctrlPressed && key is KEY_P)
               highlightPrevious(this)
-            when DOWN_ARROW
+            when key is DOWN_ARROW || (ctrlPressed && key is KEY_N)
               highlightNext(this)
-            when ENTER
+            when key is ENTER
               selectHighlighted(this)
             else
               $valueInput.val("")

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -7,7 +7,7 @@ elemicaSuggest 0.9.2-SNAPSHOT
 #
 # The elemicaSuggest function provides a simple, simple typeahead suggest
 # that simply monitors an input, calls a function to get some suggestions,
-# and add a ul next to the input with the suggestions.
+# and adds a ul next to the input with the suggestions.
 #
 # For configuration the elemicaSuggest call takes in an object literal that
 # defines the following options:
@@ -24,6 +24,12 @@ elemicaSuggest 0.9.2-SNAPSHOT
 #   to initate a typeahead search. Defaults to 2.
 # - valueInput: A jQuery object representing the DOM node which will receive
 #   the value selected by the user.
+# - buildMarkerRegExp: A function that is given the current search term, and is
+#   expected to return a regular expression whose capturing groups will be used
+#   to mark the suggestions with the class `match`. For example, if the search
+#   term was "hello", you could return /(hello)/ to mark all instances of that
+#   word in all suggestions with the `match` class. The matches are wrapped in
+#   a span.
 # - selectionIndicatorTarget: A function that takes in a jQuery object that represents
 #   the input and operates on that object to return a jQuery object of the element(s)
 #   that will receive the has-selection CSS class when a selection is made. By default
@@ -78,6 +84,8 @@ elemicaSuggest 0.9.2-SNAPSHOT
 
       noSuggestionMatched = options.noSuggestionMatched || -> true
 
+      buildMarkerRegExp = options.buildMarkerRegExp || noop
+
       removeSuggestions = (element) ->
         $(element).siblings(".suggestions").remove()
 
@@ -118,7 +126,33 @@ elemicaSuggest 0.9.2-SNAPSHOT
       currentHighlightedDisplayText = (element) ->
         $(element).parent().find(".suggestions > .active").text()
 
-      populateSuggestions = (element) -> (suggestions) ->
+      markMatches = (markerRegExp) -> (textToMark) ->
+        markedContent = []
+        currentIndex = 0
+
+        while latestMatch = markerRegExp.exec(textToMark)
+          prefix = textToMark.substring(currentIndex, latestMatch.index)
+
+          matches =
+            for i in [1...latestMatch.length]
+              $('<span />')
+                .addClass('match')
+                .text(latestMatch[i])
+
+          currentIndex = latestMatch.index + latestMatch[0].length
+
+          markedContent.push document.createTextNode(prefix)
+          markedContent.push.apply markedContent, matches
+
+          # Non-global RegExps will repeatedly match from the beginning; we
+          # break out in that case to avoid an infinite loop.
+          break unless markerRegExp.global
+
+        markedContent.push document.createTextNode(textToMark.substring(currentIndex))
+
+        markedContent
+
+      populateSuggestions = (element, markMatchRegExp) -> (suggestions) ->
         $suggestionsList = $(element).siblings(".suggestions")
 
         if $suggestionsList.length == 0
@@ -127,10 +161,19 @@ elemicaSuggest 0.9.2-SNAPSHOT
 
           $(element).parent().append($suggestionsList)
 
+        matchMarker = if markMatchRegExp? then markMatches(markMatchRegExp)
+
         $suggestionsList.empty().append(
           for suggestion in suggestions
             do (suggestion) ->
-              $suggestionLi = $("<li />").text(suggestion.display)
+              $suggestionLi = $("<li />")
+
+              if matchMarker?
+                $suggestionLi.append matchMarker(suggestion.display)
+              else
+                $suggestionLi.text suggestion.display
+
+              $suggestionLi
                 .on('mousedown element-selected', ->
                   $(element).val( suggestion.display )
                   $valueInput.val( suggestion.value )
@@ -213,7 +256,9 @@ elemicaSuggest 0.9.2-SNAPSHOT
               searchTerm = $.trim($target.val())
 
               if searchTerm.length >= minimumSearchTermLength
-                suggestFunction searchTerm, populateSuggestions(this)
+                markMatchRegExp = buildMarkerRegExp(searchTerm)
+
+                suggestFunction searchTerm, populateSuggestions(this, markMatchRegExp)
               else
                 removeSuggestions(this)
 )(jQuery)

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -214,3 +214,61 @@ describe 'Suggest', ->
       afterSelect: -> throw new Error('afterSelect should not be run if user entered nothing')
       
     $input.trigger('blur')
+
+describe 'Suggest when handling keyboard shortcuts', ->
+  onSelect = () ->
+
+  suggestFunction = (searchTerm, populateFn) ->
+    populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])
+
+  $input = $("<input />")
+  $input.elemicaSuggest
+    suggestFunction: suggestFunction
+    afterSelect: (selection) -> onSelect?(selection)
+
+  $containerDiv = $("<div />").append($input)
+
+  $input.val('bacon').trigger('keyup') # show the completion dropdown
+
+  # The following tests assume they run in order as they move through the
+  # suggestion list.
+  it 'should move the selection down if the down arrow is pressed', ->
+    keyupEvent = $.Event 'keyup'
+    keyupEvent.which = 40
+    $input.trigger keyupEvent
+
+    $containerDiv.find(".suggestions .active").text().should.equal('suggestion 2')
+
+  it 'should move the selection up if the up arrow is pressed', ->
+    keyupEvent = $.Event 'keyup'
+    keyupEvent.which = 38
+    $input.trigger keyupEvent
+
+    $containerDiv.find(".suggestions .active").text().should.equal('suggestion 1')
+
+  it 'should move the selection down if C-N is pressed', ->
+    keyupEvent = $.Event 'keyup'
+    keyupEvent.which = 78
+    keyupEvent.ctrlKey = true
+    $input.trigger keyupEvent
+
+    $containerDiv.find(".suggestions .active").text().should.equal('suggestion 2')
+
+  it 'should move the selection up if C-P is pressed', ->
+    keyupEvent = $.Event 'keyup'
+    keyupEvent.which = 80
+    keyupEvent.ctrlKey = true
+    $input.trigger keyupEvent
+
+    $containerDiv.find(".suggestions .active").text().should.equal('suggestion 1')
+
+  it 'should select the highlighted item if enter is pressed', ->
+    onSelect = (selected) ->
+      selected.display.should.equal('suggestion 1')
+      selected.value.should.equal('suggestion 1')
+
+    keyupEvent = $.Event 'keyup'
+    keyupEvent.which = 13
+    $input.trigger keyupEvent
+
+    $containerDiv.find(".suggestions").length.should.equal(0)

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -4,6 +4,7 @@ jsdom = require 'jsdom'
 jsdomWindow = jsdom.jsdom().defaultView
 jQuery = require('jquery')(jsdomWindow)
 $ = jQuery
+document = jsdomWindow.document
 fs = require 'fs'
 
 eval(fs.readFileSync('dist/elemica-suggest.js').toString())
@@ -50,6 +51,42 @@ describe 'Suggest', ->
       populateFn([{display: 'suggestion 1', value: 'suggestion 1', metadata: 'a good suggestion'}, {display: 'suggestion 2', value: 'suggestion 2', metadata: 'a great suggestion'}])
 
     elemicaSuggestionRenderingSpec(suggestFunction: suggestFunction, expectedMarkup, done)
+
+  it 'should mark matches when a marker RegExp builder is provided', (done) ->
+    expectedMarkup = '<input autocomplete=\"off\"><ul class=\"suggestions\"><li class=\"active\"><img src=\"zztop.gif\">su<span class="match">gges</span>ti<span class="match">on </span>1<span class=\"metadata\">a good suggestion</span></li><li><img src=\"walnut.jpg\">su<span class="match">gges</span>ti<span class="match">on </span>2<span class=\"metadata\">a great suggestion</span></li></ul>'
+    suggestFunction = (searchTerm, populateFn) ->
+      populateFn([
+        {display: 'suggestion 1', value: 'suggestion 1', image: 'zztop.gif', metadata: 'a good suggestion'},
+        {display: 'suggestion 2', value: 'suggestion 2', image: 'walnut.jpg', metadata: 'a great suggestion'}
+      ])
+    markerRegExpFunction = (searchTerm) ->
+      searchTerm.should.equal('bacon')
+      /(gges|on )/g
+
+    elemicaSuggestionRenderingSpec(
+      suggestFunction: suggestFunction,
+      buildMarkerRegExp: markerRegExpFunction,
+      expectedMarkup,
+      done
+    )
+
+  it 'should mark matches correctly when a non-global marker RegExp is provided', (done) ->
+    expectedMarkup = '<input autocomplete=\"off\"><ul class=\"suggestions\"><li class=\"active\"><img src=\"zztop.gif\">su<span class="match">gges</span>tion 1<span class=\"metadata\">a good suggestion</span></li><li><img src=\"walnut.jpg\">su<span class="match">gges</span>tion 2<span class=\"metadata\">a great suggestion</span></li></ul>'
+    suggestFunction = (searchTerm, populateFn) ->
+      populateFn([
+        {display: 'suggestion 1', value: 'suggestion 1', image: 'zztop.gif', metadata: 'a good suggestion'},
+        {display: 'suggestion 2', value: 'suggestion 2', image: 'walnut.jpg', metadata: 'a great suggestion'}
+      ])
+    markerRegExpFunction = (searchTerm) ->
+      searchTerm.should.equal('bacon')
+      /(gges|on )/
+
+    elemicaSuggestionRenderingSpec(
+      suggestFunction: suggestFunction,
+      buildMarkerRegExp: markerRegExpFunction,
+      expectedMarkup,
+      done
+    )
 
   it 'should correctly provide markup for suggestions with all options', (done) ->
     expectedMarkup = '<input autocomplete=\"off\"><ul class=\"suggestions\"><li class=\"active\"><img src=\"zztop.gif\">suggestion 1<span class=\"metadata\">a good suggestion</span></li><li><img src=\"walnut.jpg\">suggestion 2<span class=\"metadata\">a great suggestion</span></li></ul>'

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -9,16 +9,19 @@ fs = require 'fs'
 eval(fs.readFileSync('dist/elemica-suggest.js').toString())
 chai.should()
 
-elemicaSuggestionRenderingSpec = (suggestFunction, expectedMarkup, done) ->
+elemicaSuggestionRenderingSpec = (options, expectedMarkup, done) ->
   $containerDiv = $("<div />")
 
+  passedAfterSuggest = options.afterSuggest
   afterSuggest = ->
+    passedAfterSuggest?()
+
     $containerDiv.html().should.equal(expectedMarkup)
     done()
 
-  $input = $("<input />").elemicaSuggest
-    suggestFunction: suggestFunction,
-    afterSuggest: afterSuggest
+  options.afterSuggest = afterSuggest
+
+  $input = $("<input />").elemicaSuggest options
   $containerDiv.append($input)
 
   $input.val('bacon').trigger('keyup')
@@ -32,21 +35,21 @@ describe 'Suggest', ->
     suggestFunction = (searchTerm, populateFn) ->
       populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])
 
-    elemicaSuggestionRenderingSpec(suggestFunction, expectedMarkup, done)
+    elemicaSuggestionRenderingSpec(suggestFunction: suggestFunction, expectedMarkup, done)
 
   it 'should correctly provide markup for image suggestions', (done) ->
     expectedMarkup = '<input autocomplete=\"off\"><ul class=\"suggestions\"><li class=\"active\"><img src=\"awesome.gif\">suggestion 1</li><li><img src=\"bacon.gif\">suggestion 2</li></ul>'
     suggestFunction = (searchTerm, populateFn) ->
       populateFn([{display: 'suggestion 1', value: 'suggestion 1', image: 'awesome.gif'}, {display: 'suggestion 2', value: 'suggestion 2', image: 'bacon.gif'}])
 
-    elemicaSuggestionRenderingSpec(suggestFunction, expectedMarkup, done)
+    elemicaSuggestionRenderingSpec(suggestFunction: suggestFunction, expectedMarkup, done)
 
   it 'should correctly provide markup for metadata suggestions', (done) ->
     expectedMarkup = '<input autocomplete=\"off\"><ul class=\"suggestions\"><li class=\"active\">suggestion 1<span class=\"metadata\">a good suggestion</span></li><li>suggestion 2<span class=\"metadata\">a great suggestion</span></li></ul>'
     suggestFunction = (searchTerm, populateFn) ->
       populateFn([{display: 'suggestion 1', value: 'suggestion 1', metadata: 'a good suggestion'}, {display: 'suggestion 2', value: 'suggestion 2', metadata: 'a great suggestion'}])
 
-    elemicaSuggestionRenderingSpec(suggestFunction, expectedMarkup, done)
+    elemicaSuggestionRenderingSpec(suggestFunction: suggestFunction, expectedMarkup, done)
 
   it 'should correctly provide markup for suggestions with all options', (done) ->
     expectedMarkup = '<input autocomplete=\"off\"><ul class=\"suggestions\"><li class=\"active\"><img src=\"zztop.gif\">suggestion 1<span class=\"metadata\">a good suggestion</span></li><li><img src=\"walnut.jpg\">suggestion 2<span class=\"metadata\">a great suggestion</span></li></ul>'
@@ -56,7 +59,7 @@ describe 'Suggest', ->
         {display: 'suggestion 2', value: 'suggestion 2', image: 'walnut.jpg', metadata: 'a great suggestion'}
       ])
 
-    elemicaSuggestionRenderingSpec(suggestFunction, expectedMarkup, done)
+    elemicaSuggestionRenderingSpec(suggestFunction: suggestFunction, expectedMarkup, done)
 
   it 'should invoke afterSelect with the selected suggestion after a selection is made', (done) ->
     suggestFunction = (searchTerm, populateFn) ->
@@ -125,7 +128,7 @@ describe 'Suggest', ->
           done()
         else
           keydownEvent = $.Event 'keydown'
-          keydownEvent.keyCode = 8
+          keydownEvent.which = 8
           $input.trigger keydownEvent
 
     $containerDiv = $("<div />").append($input)


### PR DESCRIPTION
Two things here, even though it was going to be three before
I realized the third was misguided, so my branch name is all
broked…

 - We now support using Ctrl-N and Ctrl-P to move down and up
   in the suggestion list, respectively. This is in line with many/most
   other suggestion dropdowns (e.g. Github, Chrome/Safari location
   bars, vim, etc).
 - We now support providing a `buildMarkerRegExp` function that
   will allow you to provide a regular expression used to mark matches
   within a suggestion's display value with a `match` class. This can
   then be used for styling purposes to indicate the parts of the suggestion
   that matched.