### PR TITLE
Triptych (part 2): Third thing!

### DIFF
--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -66,6 +66,8 @@ elemicaSuggest 0.9.2-SNAPSHOT
       OS_LEFT = 91
       OS_RIGHT = 92
 
+      NON_PRINTALBE_KEYS = [SHIFT, CTRL, ALT, OS_LEFT, OS_RIGHT, TAB]
+
       # This function returns true if selection box is active
       # and user is selecting one of the options
       isSelectingSuggestion = -> $(".suggestions").is(":visible")
@@ -263,9 +265,7 @@ elemicaSuggest 0.9.2-SNAPSHOT
             when key is ENTER
               selectHighlighted(this)
             # Ignore other non-printable keys.
-            when key isnt CTRL && key isnt ALT && key isnt SHIFT &&
-                 key isnt OS_LEFT && key isnt OS_RIGHT &&
-                 key isnt TAB
+            when key not in NON_PRINTALBE_KEYS
               $valueInput.val("")
               $target = $(event.target)
               selectionIndicatorTarget($target).removeClass("has-selection")

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -137,6 +137,9 @@ elemicaSuggest 0.9.2-SNAPSHOT
         currentIndex = 0
 
         while latestMatch = markerRegExp.exec(textToMark)
+          # If we have a zero-width match, bail before we infini-loop.
+          break if latestMatch[0].length == 0
+
           prefix = textToMark.substring(currentIndex, latestMatch.index)
 
           matches =
@@ -145,7 +148,7 @@ elemicaSuggest 0.9.2-SNAPSHOT
                 .addClass('match')
                 .text(latestMatch[i])
 
-          currentIndex = latestMatch.index + latestMatch[0].length
+          currentIndex = latestMatch.index + Math.max(latestMatch[0].length, 1)
 
           markedContent.push document.createTextNode(prefix)
           markedContent.push.apply markedContent, matches

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -60,6 +60,12 @@ elemicaSuggest 0.9.2-SNAPSHOT
       TAB = 9
       BACKSPACE = 8
 
+      SHIFT = 16
+      CTRL = 17
+      ALT = 18
+      OS_LEFT = 91
+      OS_RIGHT = 92
+
       # This function returns true if selection box is active
       # and user is selecting one of the options
       isSelectingSuggestion = -> $(".suggestions").is(":visible")
@@ -227,7 +233,11 @@ elemicaSuggest 0.9.2-SNAPSHOT
               afterSelect(null) if originalValue != ""
 
         $(this).on 'keydown', (event) =>
-          if event.which == UP_ARROW || event.which == DOWN_ARROW
+          key = event.which
+          ctrlPressed = event.ctrlKey
+
+          if key is UP_ARROW || key is DOWN_ARROW ||
+             (ctrlPressed && (key is KEY_P || key is KEY_N))
             event.preventDefault()
           else if event.which == ENTER && isSelectingSuggestion()
             event.preventDefault()
@@ -249,7 +259,8 @@ elemicaSuggest 0.9.2-SNAPSHOT
               highlightNext(this)
             when key is ENTER
               selectHighlighted(this)
-            else
+            # Ignore other non-printable keys.
+            when key isnt CTRL && key isnt ALT && key isnt SHIFT && key isnt OS_LEFT && key isnt OS_RIGHT
               $valueInput.val("")
               $target = $(event.target)
               selectionIndicatorTarget($target).removeClass("has-selection")

--- a/elemica-suggest.coffee
+++ b/elemica-suggest.coffee
@@ -260,7 +260,9 @@ elemicaSuggest 0.9.2-SNAPSHOT
             when key is ENTER
               selectHighlighted(this)
             # Ignore other non-printable keys.
-            when key isnt CTRL && key isnt ALT && key isnt SHIFT && key isnt OS_LEFT && key isnt OS_RIGHT
+            when key isnt CTRL && key isnt ALT && key isnt SHIFT &&
+                 key isnt OS_LEFT && key isnt OS_RIGHT &&
+                 key isnt TAB
               $valueInput.val("")
               $target = $(event.target)
               selectionIndicatorTarget($target).removeClass("has-selection")

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -257,6 +257,7 @@ describe 'Suggest', ->
 
 describe 'Suggest when handling keyboard shortcuts', ->
   onSelect = () ->
+  onSuggest = () ->
 
   suggestFunction = (searchTerm, populateFn) ->
     populateFn([{display: 'suggestion 1', value: 'suggestion 1'}, {display: 'suggestion 2', value: 'suggestion 2'}])
@@ -265,40 +266,38 @@ describe 'Suggest when handling keyboard shortcuts', ->
   $input.elemicaSuggest
     suggestFunction: suggestFunction
     afterSelect: (selection) -> onSelect?(selection)
+    afterSuggest: () -> onSuggest?()
 
   $containerDiv = $("<div />").append($input)
 
   $input.val('bacon').trigger('keyup') # show the completion dropdown
 
+  triggerKeyUp = ($input, keyCode, ctrlKey) ->
+    keyupEvent = $.Event 'keyup'
+    keyupEvent.which = keyCode
+    keyupEvent.ctrlKey = ctrlKey || false
+
+    $input.trigger keyupEvent
+
   # The following tests assume they run in order as they move through the
   # suggestion list.
   it 'should move the selection down if the down arrow is pressed', ->
-    keyupEvent = $.Event 'keyup'
-    keyupEvent.which = 40
-    $input.trigger keyupEvent
+    triggerKeyUp $input, 40
 
     $containerDiv.find(".suggestions .active").text().should.equal('suggestion 2')
 
   it 'should move the selection up if the up arrow is pressed', ->
-    keyupEvent = $.Event 'keyup'
-    keyupEvent.which = 38
-    $input.trigger keyupEvent
+    triggerKeyUp $input, 38
 
     $containerDiv.find(".suggestions .active").text().should.equal('suggestion 1')
 
   it 'should move the selection down if C-N is pressed', ->
-    keyupEvent = $.Event 'keyup'
-    keyupEvent.which = 78
-    keyupEvent.ctrlKey = true
-    $input.trigger keyupEvent
+    triggerKeyUp $input, 78, true
 
     $containerDiv.find(".suggestions .active").text().should.equal('suggestion 2')
 
   it 'should move the selection up if C-P is pressed', ->
-    keyupEvent = $.Event 'keyup'
-    keyupEvent.which = 80
-    keyupEvent.ctrlKey = true
-    $input.trigger keyupEvent
+    triggerKeyUp $input, 80, true
 
     $containerDiv.find(".suggestions .active").text().should.equal('suggestion 1')
 
@@ -307,8 +306,27 @@ describe 'Suggest when handling keyboard shortcuts', ->
       selected.display.should.equal('suggestion 1')
       selected.value.should.equal('suggestion 1')
 
-    keyupEvent = $.Event 'keyup'
-    keyupEvent.which = 13
-    $input.trigger keyupEvent
+    triggerKeyUp $input, 13, true
 
     $containerDiv.find(".suggestions").length.should.equal(0)
+
+  it 'should not trigger a search on keyups for non-printable characters', ->
+    searchCalls = 0
+    onSuggest = -> searchCalls += 1
+
+    triggerKeyUp $input, 13
+    triggerKeyUp $input, 16
+    triggerKeyUp $input, 17
+    triggerKeyUp $input, 18
+    triggerKeyUp $input, 91
+    triggerKeyUp $input, 92
+
+    searchCalls.should.equal(0)
+
+  it 'should trigger a search on keyups for non-printable characters', ->
+    searchCalls = 0
+    onSuggest = -> searchCalls += 1
+
+    triggerKeyUp $input, 25
+
+    searchCalls.should.equal(1)

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -88,6 +88,25 @@ describe 'Suggest', ->
       done
     )
 
+  it 'should abort match marking when an empty match occurs', (done) ->
+    expectedMarkup = '<input autocomplete=\"off\"><ul class=\"suggestions\"><li class=\"active\"><img src=\"zztop.gif\">suggestion 1<span class=\"metadata\">a good suggestion</span></li><li><img src=\"walnut.jpg\">suggestion 2<span class=\"metadata\">a great suggestion</span></li></ul>'
+    suggestFunction = (searchTerm, populateFn) ->
+      populateFn([
+        {display: 'suggestion 1', value: 'suggestion 1', image: 'zztop.gif', metadata: 'a good suggestion'},
+        {display: 'suggestion 2', value: 'suggestion 2', image: 'walnut.jpg', metadata: 'a great suggestion'}
+      ])
+    markerRegExpFunction = (searchTerm) ->
+      searchTerm.should.equal('bacon')
+      /(gges|)/
+
+    elemicaSuggestionRenderingSpec(
+      suggestFunction: suggestFunction,
+      buildMarkerRegExp: markerRegExpFunction,
+      expectedMarkup,
+      done
+    )
+
+
   it 'should correctly provide markup for suggestions with all options', (done) ->
     expectedMarkup = '<input autocomplete=\"off\"><ul class=\"suggestions\"><li class=\"active\"><img src=\"zztop.gif\">suggestion 1<span class=\"metadata\">a good suggestion</span></li><li><img src=\"walnut.jpg\">suggestion 2<span class=\"metadata\">a great suggestion</span></li></ul>'
     suggestFunction = (searchTerm, populateFn) ->

--- a/test/elemica-suggest-spec.coffee
+++ b/test/elemica-suggest-spec.coffee
@@ -314,6 +314,7 @@ describe 'Suggest when handling keyboard shortcuts', ->
     searchCalls = 0
     onSuggest = -> searchCalls += 1
 
+    triggerKeyUp $input, 9
     triggerKeyUp $input, 13
     triggerKeyUp $input, 16
     triggerKeyUp $input, 17


### PR DESCRIPTION
We avoid triggering completion on non-printable keyups. This
takes care of a new bug with C-N and C-P, which would trigger
new searches when you released Ctrl, which would clear your
down/up movement. However, it also takes care of an old bug
where the completion popup would immediately appear when
you tabbed into a completable input, even if you didn't want to
select something else. With a misplaced mouse, you could
change your selection and wreak havoc.

We now ignore tab as well, so that you can trigger the completion
by starting to type in the input, not simply by tabbing to it.